### PR TITLE
Update chefdk & use Debian 9 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ LABEL \
 
 USER root
 
-ENV CHEFDK_VERSION=3.0.36
+ENV CHEFDK_VERSION=3.12.10
 
 RUN apt-get install -y \
-      ruby \
-      ruby-dev && \
+    ruby \
+    ruby-dev && \
     gem install bundler && \
-    curl -O https://packages.chef.io/files/stable/chefdk/${CHEFDK_VERSION}/ubuntu/16.04/chefdk_${CHEFDK_VERSION}-1_amd64.deb && \
+    curl -O https://packages.chef.io/files/stable/chefdk/${CHEFDK_VERSION}/debian/9/chefdk_${CHEFDK_VERSION}-1_amd64.deb && \
     dpkg -i chefdk_${CHEFDK_VERSION}-1_amd64.deb && \
     rm -rf chefdk_${CHEFDK_VERSION}-1_amd64.deb
 


### PR DESCRIPTION
Currently `openjdk:8-jre` is running Debian 9:

```
$ docker run --rm docker.io/library/openjdk:8-jre cat /etc/debian_version
9.11
```

This updates us to the latest chefdk that doesn't include chef15

```
$ chef --version
Chef Development Kit Version: 3.12.10
chef-client version: 14.14.29
delivery version: master (4b21ec7e07fdfa82e86aa80e4f2372dde8e368bb)
berks version: 7.0.8
kitchen version: 1.25.0
inspec version: 3.9.3
```
