### PR TITLE
Update chefdk version and upgrade to latest upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ LABEL \
 
 USER root
 
-ENV CHEFDK_VERSION=3.12.10
+ENV CHEFDK_VERSION=3.13.1
 
 RUN apt-get install -y \
     ruby \


### PR DESCRIPTION
Need to trigger a new build on the master branch to update `latest`, so might as well update to the latest chefdk while we're at it.

Even though chefdk doesn't have a debian 10 package, installing the debian 9 package seems to be working:
```
$ chef -v
Chef Development Kit Version: 3.13.1
chef-client version: 14.14.29
delivery version: master (4b21ec7e07fdfa82e86aa80e4f2372dde8e368bb)
berks version: 7.0.8
kitchen version: 1.25.0
inspec version: 3.9.3
```